### PR TITLE
[Discussion] More complicate pokemon's memo

### DIFF
--- a/src/locales/en/pokemon-summary.ts
+++ b/src/locales/en/pokemon-summary.ts
@@ -8,10 +8,13 @@ export const pokemonSummary: SimpleTranslationEntries = {
   "unknownTrainer": "Unknown",
   "ot": "OT",
   "luck": "Luck",
-  "nature": "nature",
-  "apparently": "apparently",
-  "metAtLv": "met at Lv.",
   "expPoints": "Exp. Points",
   "nextLv": "Next Lv.",
   "cancel": "Cancel",
+
+  "memoString": "{{natureFragment}} nature,\n{{metFragment}}",
+  "metFragment": {
+    "normal": "met at Lv{{level}},\n{{biome}}.",
+    "apparently": "apparently met at Lv{{level}},\n{{biome}}.",
+  }
 } as const;

--- a/src/locales/en/pokemon-summary.ts
+++ b/src/locales/en/pokemon-summary.ts
@@ -1,6 +1,6 @@
-import { SimpleTranslationEntries } from "#app/interfaces/locales.js";
+import { PokemonSummaryEntries } from "#app/interfaces/locales.js";
 
-export const pokemonSummary: SimpleTranslationEntries = {
+export const pokemonSummary: PokemonSummaryEntries = {
   "pokemonInfo": "Pokémon Info",
   "status": "Status",
   "powerAccuracyCategory": "Power\nAccuracy\nCategory",

--- a/src/locales/ko/pokemon-summary.ts
+++ b/src/locales/ko/pokemon-summary.ts
@@ -1,6 +1,6 @@
-import { SimpleTranslationEntries } from "#app/interfaces/locales.js";
+import { PokemonSummaryEntries } from "#app/interfaces/locales.js";
 
-export const pokemonSummary: SimpleTranslationEntries = {
+export const pokemonSummary: PokemonSummaryEntries = {
   "pokemonInfo": "포켓몬 정보",
   "status": "능력치",
   "powerAccuracyCategory": "위력\n명중\n분류",
@@ -8,10 +8,40 @@ export const pokemonSummary: SimpleTranslationEntries = {
   "unknownTrainer": "알수없음",
   "ot": "어버이",
   "luck": "행운",
-  "nature": "성격",
-  "apparently": "apparently",
-  "metAtLv": "met at Lv.",
   "expPoints": "현재 경험치",
   "nextLv": "다음 레벨까지",
   "cancel": "그만둔다",
+
+  "memoString": "{{natureFragment}}.\n{{metFragment}}",
+  "metFragment": {
+    "normal": "{{biome}}에서\nLv{{level}}일 때 만났다.",
+    "apparently": "{{biome}}에서\nLv{{level}}일 때 만난 것 같다.",
+  },
+  "natureFragment": {
+    "Hardy": "{{nature}}하는 성격",
+    "Lonely": "{{nature}}을 타는 성격",
+    "Brave": "{{nature}}한 성격",
+    "Adamant": "{{nature}}스러운 성격",
+    "Naughty" : "{{nature}}같은 성격",
+    "Bold" : "{{nature}}한 성격",
+    "Docile" : "{{nature}}한 성격",
+    "Relaxed" : "{{nature}}한 성격",
+    "Impish" : "{{nature}}같은 성격",
+    "Lax" : "{{nature}}거리는 성격",
+    "Timid" : "{{nature}}같은 성격",
+    "Hasty" : "{{nature}}한 성격",
+    "Serious" : "{{nature}}한 성격",
+    "Jolly" : "{{nature}}한 성격",
+    "Naive" : "{{nature}}한 성격",
+    "Modest" : "{{nature}}스러운 성격",
+    "Mild" : "{{nature}}한 성격",
+    "Quiet" : "{{nature}}한 성격",
+    "Bashful" : "{{nature}}을 타는 성격",
+    "Rash" : "{{nature}}거리는 성격",
+    "Calm" : "{{nature}}한 성격",
+    "Gentle" : "{{nature}}한 성격",
+    "Sassy" : "{{nature}}진 성격",
+    "Careful" : "{{nature}}한 성격",
+    "Quirky": "{{nature}}스러운 성격",
+  },
 } as const;

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -15,7 +15,7 @@ import { Stat, getStatName } from "../data/pokemon-stat";
 import { PokemonHeldItemModifier } from "../modifier/modifier";
 import { StatusEffect } from "../data/status-effect";
 import { getBiomeName } from "../data/biomes";
-import { getNatureName, getNatureStatMultiplier } from "../data/nature";
+import { Nature, getNatureName, getNatureStatMultiplier } from "../data/nature";
 import { loggedInUser } from "../account";
 import { Variant, getVariantTint } from "#app/data/variant";
 import {Button} from "#enums/buttons";
@@ -796,7 +796,20 @@ export default class SummaryUiHandler extends UiHandler {
       this.passiveContainer?.nameText.setVisible(false);
       this.passiveContainer?.descriptionText.setVisible(false);
 
-      const memoString = `${getBBCodeFrag(Utils.toReadableString(getNatureName(this.pokemon.getNature())), TextStyle.SUMMARY_RED)}${getBBCodeFrag(` ${i18next.t("pokemonSummary:nature")},`, TextStyle.WINDOW_ALT)}\n${getBBCodeFrag(`${this.pokemon.metBiome === -1 ? `${i18next.t("pokemonSummary:apparently")} ` : ""}${i18next.t("pokemonSummary:metAtLv")}`, TextStyle.WINDOW_ALT)}${getBBCodeFrag(this.pokemon.metLevel.toString(), TextStyle.SUMMARY_RED)}${getBBCodeFrag(",", TextStyle.WINDOW_ALT)}\n${getBBCodeFrag(getBiomeName(this.pokemon.metBiome), TextStyle.SUMMARY_RED)}${getBBCodeFrag(".", TextStyle.WINDOW_ALT)}`;
+      const closeFragment = getBBCodeFrag("", TextStyle.WINDOW_ALT);
+      const rawNature = Utils.toReadableString(Nature[this.pokemon.getNature()]);
+      const nature = `${getBBCodeFrag(Utils.toReadableString(getNatureName(this.pokemon.getNature())), TextStyle.SUMMARY_RED)}${closeFragment}`;
+
+      const memoString = i18next.t("pokemonSummary:memoString", {
+        metFragment: i18next.t(`pokemonSummary:metFragment.${this.pokemon.metBiome === -1? "apparently": "normal"}`, {
+          biome: `${getBBCodeFrag(getBiomeName(this.pokemon.metBiome), TextStyle.SUMMARY_RED)}${closeFragment}`,
+          level: `${getBBCodeFrag(this.pokemon.metLevel.toString(), TextStyle.SUMMARY_RED)}${closeFragment}`,
+        }),
+        natureFragment:
+          i18next.exists(`pokemonSummary:natureFragment.${rawNature}`) ?
+            i18next.t(`pokemonSummary:natureFragment.${rawNature}`, { nature: nature }) :
+            nature,
+      });
 
       const memoText = addBBCodeTextObject(this.scene, 7, 113, memoString, TextStyle.WINDOW_ALT);
       memoText.setOrigin(0, 0);


### PR DESCRIPTION
## What are the changes?
Can change order of pokemon's memo

## Why am I doing these changes?
Some language (Korean, Japanese-on PR, maybe other?) use different pokemon memo.
Screenshots below can help.

## What did change?
Make interface for pokemon summary (maybe not completed)
Apply example for English and Korean.


### Screenshots/Videos
![image](https://github.com/Nolway/pokerogue/assets/87186129/7d119c93-57b7-48df-8c8d-274053e9847c)

In korean, some kinds of postpositions is used for nature (*red bg*).
Memo order is nature-biome-level.
When met `apparently`, memo is differentiated (*green bg*), not just be added.

## How to test the changes?
Check pokemon summary on English and Korean.
In other language they won't work yet. (Just printed using locales/en)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?